### PR TITLE
fix really random crash on perfectly matching dual waves

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,6 +109,10 @@ class $modify(WTDFHardStreak, HardStreak) {
   // them until i trial-and-errored into something that kind of works but not completely
   // people who actually know how to generate proper offset polylines: please tell me what i am missing
   void fixPoints(std::vector<CCPoint>& trailPath, float offset, std::vector<CCPoint>& points, std::vector<bool>& labels, std::vector<CCPoint>& otherPoints) {
+    // vectors might not be the same size
+    if (points.size() != labels.size() || points.size() < 2) return;
+    if (otherPoints.size() != points.size()) return;
+
     for (int i = 0; i < labels.size(); i++) {
       CCPoint nextSegmentP1, nextSegmentP2, prevSegmentP1, prevSegmentP2;
       bool nextFinished = false, prevFinished = false;


### PR DESCRIPTION
hi! this fixes a crash i've encountered when botting [this level](https://www.youtube.com/watch?v=bRxfoJPBmZI) (dm me on discord @peony if you want a copy)

the program was assuming three vectors were the same size so i just added a check for that